### PR TITLE
Change default logdirectory

### DIFF
--- a/lib/aiota.js
+++ b/lib/aiota.js
@@ -79,7 +79,7 @@ function init(db, callback)
 					amqp : conf.amqp,
 					directories : {
 						aiota : aiota_dir,
-						log : "/var/log/aiota/"
+						log : "var/log/aiota/"
 					}
 				};
 				


### PR DESCRIPTION
The default log directory resides at the root of the filesystem. A normal logged in user does not have access to this.
The default log directory has been changed to be placed in the current directory (i.e. the directory from where the services are started).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/aiota/master/1)

<!-- Reviewable:end -->
